### PR TITLE
Fix beats_version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,7 +20,7 @@
 
 - name: "Ensure {{ package }} is installed"
   apt:
-    name: "{{ package }}={{ beats_ver }}"
+    name: "{{ package }}={{ beats_version }}"
     state: present
 
 - name: "Ensure {{ package }} is started and enabled on startup"


### PR DESCRIPTION
Use newer beats_version variable consistently.

When trying to specify `beats_version: 6.8.2`, it seems 6.7.2 (the default) is still being installed.